### PR TITLE
Fix uploading due to 3.5.0 data format changes

### DIFF
--- a/fossdriver/parser.py
+++ b/fossdriver/parser.py
@@ -32,6 +32,21 @@ class ParsedJob(object):
     def __repr__(self):
         return "Job {}: {}, {}".format(self._id, self.agent, self.status)
 
+def parseVersionNumber(content):
+    """
+    Parses content returned from a server.Version() call.
+    Extracts and returns the Fossology server version as a string.
+    """
+    # parsing the full HTML page content
+    soup = bs4.BeautifulSoup(content, "lxml")
+    # looking for the span with id versionInfo
+    elt = soup.find(id='versionInfo')
+    # parse its text to remove 'Version: [X.Y.Z]' at the beginning
+    partial = elt.contents[0].lstrip('Version: [')
+    # now remove everything after the next ']'
+    version = partial.split(']')[0]
+    return version
+
 def parseUploadDataForFolderLineItem(lineItem):
     """
     Parses one line item for parsing the uploads in a folder.

--- a/fossdriver/server.py
+++ b/fossdriver/server.py
@@ -30,6 +30,7 @@ class FossServer(object):
         # connection data
         self.config = config
         self.session = requests.Session()
+        self.serverVersion = ""
 
     def _get(self, endpoint):
         """Helper function: Make a GET call to the Fossology server."""
@@ -75,8 +76,17 @@ class FossServer(object):
         logging.debug("POST (file): " + url + " " + str(r))
         return r
 
+    def Version(self):
+        """Get the version number of the Fossology server."""
+        endpoint = "/repo/"
+        results = self._get(endpoint)
+        return fossdriver.parser.parseVersionNumber(results.content)
+
     def Login(self):
-        """Log in to Fossology server. Should be the first call made."""
+        """
+        Log in to Fossology server. Should be the first call made,
+        other than Version calls which can occur without logging in.
+        """
         endpoint = "/repo/?mod=auth"
         values = {
             "username": self.config.username,
@@ -84,6 +94,7 @@ class FossServer(object):
         }
         self._post(endpoint, values)
         # FIXME check for success?
+        self.serverVersion = self.Version()
 
     def GetFolderNum(self, folderName):
         """Find folder ID number for the given folder name from Fossology server."""

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fossdriver",
-    version="0.0.2",
+    version="0.0.3",
     author="Steve Winslow",
     author_email="swinslow@gmail.com",
     description="Python interface to control a FOSSology server",
@@ -29,5 +29,6 @@ setuptools.setup(
         "requests-toolbelt == 0.8.0",
         "bs4 == 0.0.1",
         "lxml == 4.2.1",
+        "version-parser == 1.0.0",
     ]
 )


### PR DESCRIPTION
Fixes #17 

This fixes an issue where version 3.5.0 of the Fossology server changed the job report data format from XML to JSON.

fossdriver now checks the server version at login. When subsequently getting job report data it will now check to see whether the server is 3.5.0 or later (in which case it will parse the response as JSON) or earlier (in which case it will parse the response as XML).

Signed-off-by: Steve Winslow <swinslow@gmail.com>