### PR TITLE
fix(tasks): Fixes #24 by checking server version

### DIFF
--- a/fossdriver/tasks.py
+++ b/fossdriver/tasks.py
@@ -197,12 +197,18 @@ class BulkTextMatch(Task):
 
     def add(self, licenseName):
         """Create an "add" action and include it in the bulk actions."""
-        actionTuple = (licenseName, "add")
+        if self.server.IsAtLeastVersion("3.6.0"):
+            actionTuple = (licenseName, "Add")
+        else:
+            actionTuple = (licenseName, "add")
         self.actionTuples.append(actionTuple)
 
     def remove(self, licenseName):
         """Create a "remove" action and include it in the bulk actions."""
-        actionTuple = (licenseName, "remove")
+        if self.server.IsAtLeastVersion("3.6.0"):
+            actionTuple = (licenseName, "Remove")
+        else:
+            actionTuple = (licenseName, "remove")
         self.actionTuples.append(actionTuple)
 
     def _findLicenseID(self, licenseName):


### PR DESCRIPTION
When setting up a BulkTextMatch action, the task will now check
the server version first. If it is at least 3.6.0, then the
action type's first letter will be capitalized ("Add" or "Remove")
else it will remain lowercase ("add" or "remove").

If the error from #24 is seen for versions between 3.3.0 and
3.6.0, then the minimum version check can be modified accordingly.

Signed-off-by: Steve Winslow <swinslow@gmail.com>