### PR TITLE
Add support to retrieve upload stats

### DIFF
--- a/fossdriver/parser.py
+++ b/fossdriver/parser.py
@@ -256,3 +256,32 @@ def parseSingleJobData(content):
         job.status == "Completed"):
         job.reportId = int(jobReportIdString)
     return job
+
+def parseStatisticsFromLicenseBrowser(content):
+    # parsing the full HTML page content
+    soup = bs4.BeautifulSoup(content, "lxml")
+    # looking for the table with id licsummary
+    elt = soup.find(id='licsummary')
+    tds = elt.find_all("td")
+    # check that they match expected labels, if so then capture values
+    if len(tds) < 16:
+        return []
+    if (tds[0].contents[0] != "Unique licenses" or
+       tds[3].contents[0] != "Files" or
+       tds[4].contents[0] != "Unique scanner detected licenses" or
+       tds[7].contents[0] != "Unique concluded licenses" or
+       tds[8].contents[0] != "Licenses found" or
+       tds[11].contents[0] != "Licenses concluded" or
+       tds[12].contents[0] != "Files with no detected licenses" or
+       tds[15].contents[0] != "Concluded files with no detected licenses"):
+       return []
+    return [
+        ("Unique licenses", int(tds[1].contents[0])),
+        ("Files", int(tds[2].contents[0])),
+        ("Unique scanner detected licenses", int(tds[5].contents[0])),
+        ("Unique concluded licenses", int(tds[6].contents[0])),
+        ("Licenses found", int(tds[9].contents[0])),
+        ("Licenses concluded", int(tds[10].contents[0])),
+        ("Files with no detected licenses", int(tds[13].contents[0])),
+        ("Concluded files with no detected licenses", int(tds[14].contents[0])),
+    ]

--- a/fossdriver/server.py
+++ b/fossdriver/server.py
@@ -234,6 +234,21 @@ class FossServer(object):
         licenses = fossdriver.parser.parseAllLicenseData(results.content)
         return licenses
 
+    def GetUploadStatistics(self, uploadNum, itemNum):
+        """
+        Obtain a list of tuples in (str, int) format, where each str is one
+        of the "Summary" values from the left side of the License view, and
+        the int is the corresponding count.
+        Requires upload and item numbers due to Fossology server interface.
+        Arguments:
+            - uploadNum: valid ID number for an existing upload.
+            - topTreeItemNum: valid ID number for an item in that upload.
+        """
+        endpoint = "/repo/?mod=license&upload={}&item={}".format(uploadNum, itemNum)
+        results = self._get(endpoint)
+        stats = fossdriver.parser.parseStatisticsFromLicenseBrowser(results.content)
+        return stats
+
     def FindLicenseInParsedList(self, parsedLicenses, licName):
         """
         Find the ParsedLicense object with the given license name.


### PR DESCRIPTION
This will retrieve the license browser for the root of a specified
upload, and will parse and return the statistics of the "Summary"
block viewable on the left-hand side of the page.

It is tested on a v3.6.0 Fossology server; version checking can be
added if needed.

Fixes #26

Signed-off-by: Steve Winslow <steve@swinslow.net>