### PR TITLE
change(parser): Fixes #32 for stats format

### DIFF
--- a/fossdriver/parser.py
+++ b/fossdriver/parser.py
@@ -265,7 +265,7 @@ def parseStatisticsFromLicenseBrowser(content):
     tds = elt.find_all("td")
     # check that they match expected labels, if so then capture values
     if len(tds) < 16:
-        return []
+        return {}
     if (tds[0].contents[0] != "Unique licenses" or
        tds[3].contents[0] != "Files" or
        tds[4].contents[0] != "Unique scanner detected licenses" or
@@ -274,14 +274,14 @@ def parseStatisticsFromLicenseBrowser(content):
        tds[11].contents[0] != "Licenses concluded" or
        tds[12].contents[0] != "Files with no detected licenses" or
        tds[15].contents[0] != "Concluded files with no detected licenses"):
-       return []
-    return [
-        ("Unique licenses", int(tds[1].contents[0])),
-        ("Files", int(tds[2].contents[0])),
-        ("Unique scanner detected licenses", int(tds[5].contents[0])),
-        ("Unique concluded licenses", int(tds[6].contents[0])),
-        ("Licenses found", int(tds[9].contents[0])),
-        ("Licenses concluded", int(tds[10].contents[0])),
-        ("Files with no detected licenses", int(tds[13].contents[0])),
-        ("Concluded files with no detected licenses", int(tds[14].contents[0])),
-    ]
+       return {}
+    return {
+        "Unique licenses": int(tds[1].contents[0]),
+        "Files": int(tds[2].contents[0]),
+        "Unique scanner detected licenses": int(tds[5].contents[0]),
+        "Unique concluded licenses": int(tds[6].contents[0]),
+        "Licenses found": int(tds[9].contents[0]),
+        "Licenses concluded": int(tds[10].contents[0]),
+        "Files with no detected licenses": int(tds[13].contents[0]),
+        "Concluded files with no detected licenses": int(tds[14].contents[0]),
+    }


### PR DESCRIPTION
This changes the stats function so that it will return stats as a
dictionary, rather than an array of tuples.

Fixes #32 

Signed-off-by: Steve Winslow <steve@swinslow.net>