### PR TITLE
Add missing import in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the fossdriver project.
 # SPDX-License-Identifier: BSD-3-Clause OR MIT
 
+import setuptools
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 


### PR DESCRIPTION
"setuptools" is used in setup.py without being imported first.

And this, for example, breaks "python3 setup.py install".