### PR TITLE
server: Consider 'unknown' to be an arbitrarily new version

### DIFF
--- a/fossdriver/server.py
+++ b/fossdriver/server.py
@@ -91,6 +91,11 @@ class FossServer(object):
         further testing on whether it correctly handles e.g. RC- and
         interim commit versions.
         """
+        if self.serverVersion == 'unknown':
+            # Assume git clones are a recent version, we can't really do
+            # anything better than this...
+            return True
+
         serverVer = Version(self.serverVersion)
         compareVer = Version(compareVersionStr)
         return serverVer >= compareVer


### PR DESCRIPTION
Recent Docker container images from
https://hub.docker.com/r/fossology/fossology show up as version
'unknown', which is not comparable. It seems like the best we can do
here is to assume that 'unknown' means a modern version.

Resolves: https://github.com/fossology/fossdriver/issues/41