### PR TITLE
Update lxml to version 4.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "requests == 2.20.0",
         "requests-toolbelt == 0.8.0",
         "bs4 == 0.0.1",
-        "lxml == 4.2.1",
+        "lxml == 4.6.3",
         "version-parser == 1.0.0",
     ]
 )


### PR DESCRIPTION
Resolves an lxml version compatibility issue in Windows environments

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>