### PR TITLE
Retry login

### DIFF
--- a/fossdriver/server.py
+++ b/fossdriver/server.py
@@ -13,9 +13,6 @@ import io
 import sys
 from version_parser import Version
 
-# TODO: REMOVE DEBUG
-import pdb
-
 import fossdriver.parser
 
 NOT_LOGGED_IN_RESPONSE = 'session timed out'
@@ -48,21 +45,19 @@ class FossServer(object):
         """ Returns true if the user is logged in """
         return not (response.ok and response.text != None and NOT_LOGGED_IN_RESPONSE in response.text)
 
-    def _retryRequest(self, fn, *args):
+    def _retryRequest(self, fn, *args, **kwargs):
         """ Retries a Request function checking for being logged in.  
         fn is function to call that returns a request object """
         exc = None
         connectionRetries = 0
         while connectionRetries < 5 and self.loginAttempts <= MAX_LOGIN_ATTEMPTS:
             try:
-                r = fn(*args);
+                r = fn(*args, **kwargs);
                 if self._checkLoggedIn(r):
                     self.loginAttempts = 0
                     return r
                 else:
                     self.loginAttempts += 1
-                    # TODO: Remove debug
-                    pdb.set_trace()
                     self.Login()
             except requests.exceptions.ConnectionError as e:
                 # try again after a brief pause
@@ -93,7 +88,7 @@ class FossServer(object):
         url = self.config.serverUrl + endpoint
         data = values
         exc = None
-        logging.debug("POST: " + url + " " + str(r))
+        logging.debug("POST: " + url)
         return self._retryRequest(self.session.post, url, data=data);
 
     def _postFile(self, endpoint, values):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "requests == 2.20.0",
         "requests-toolbelt == 0.8.0",
         "bs4 == 0.0.1",
-        "lxml == 4.2.1",
+        "lxml == 4.6.3",
         "version-parser == 1.0.0",
     ]
 )


### PR DESCRIPTION
Fixes issue #44 

Notes:
- I set breakpoint to review the return status and text from the post and get requests
- Return status was 200 even when there was an authentication error
- Login post returned a status 500 (server error) even though it seemed to succeed
- Implementation involves searching return text for patterns associated with failed logins - a bit hacky, but seems like the best approach
- Verified post and get failures by forcing timeouts with debug breakpoints